### PR TITLE
chore: add missing yarn install to the publish job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -154,7 +154,9 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: "./packages/${{ github.event.inputs.snap-package-dir }}/"
-        run: yarn publish ${{ steps.publish.outputs.args }}
+        run: |
+          yarn install
+          yarn publish ${{ steps.publish.outputs.args }}
 
       - name: Generate Github Release
         uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds the missing `yarn install` to the publish job. 
- ~~Adds the `yarn run lint` command to the safety checks.~~
   - Linting is currently broken. 

### Related Issues

- Closes #39 (again)