### PR TITLE
Refactor : Hedera Types Into Types Folder

### DIFF
--- a/packages/hedera-wallet-snap/packages/snap/snap.manifest.json
+++ b/packages/hedera-wallet-snap/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/hashgraph/hedera-metamask-snaps.git"
   },
   "source": {
-    "shasum": "GW5ZWO6uAdBmSjuVTZtszHzTfHTb4/uASBVTOxvPCU4=",
+    "shasum": "6eGIuaFgOONBTvIHg2OUzo0EV2xsIsJYdddCibD/mAY=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/account/approveAllowance.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/account/approveAllowance.ts
@@ -21,7 +21,7 @@
 import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import _ from 'lodash';
-import { MirrorTokenInfo, TxReceipt } from '../../services/hedera';
+import { MirrorTokenInfo, TxReceipt } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/account/deleteAccount.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/account/deleteAccount.ts
@@ -20,7 +20,7 @@
 
 import { providerErrors } from '@metamask/rpc-errors';
 import { heading, text } from '@metamask/snaps-ui';
-import { AccountBalance, TxReceipt } from '../../services/hedera';
+import { AccountBalance, TxReceipt } from '../../types/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';
 import { updateSnapState } from '../../snap/state';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/account/deleteAllowance.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/account/deleteAllowance.ts
@@ -21,7 +21,7 @@
 import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import _ from 'lodash';
-import { MirrorTokenInfo, TxReceipt } from '../../services/hedera';
+import { MirrorTokenInfo, TxReceipt } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/account/stakeHbar.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/account/stakeHbar.ts
@@ -22,7 +22,7 @@ import { Hbar, HbarUnit } from '@hashgraph/sdk';
 import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import _ from 'lodash';
-import { TxReceipt } from '../../services/hedera';
+import { TxReceipt } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/hts/associateTokens.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/hts/associateTokens.ts
@@ -21,7 +21,7 @@
 import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import _ from 'lodash';
-import { TxReceipt } from '../../services/hedera';
+import { TxReceipt } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/transactions/getTransactions.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/transactions/getTransactions.ts
@@ -20,7 +20,7 @@
 
 import { providerErrors } from '@metamask/rpc-errors';
 import _ from 'lodash';
-import { MirrorTransactionInfo } from '../../services/hedera';
+import { MirrorTransactionInfo } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { updateSnapState } from '../../snap/state';
 import { GetTransactionsRequestParams } from '../../types/params';

--- a/packages/hedera-wallet-snap/packages/snap/src/rpc/transactions/transferCrypto.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/rpc/transactions/transferCrypto.ts
@@ -21,7 +21,7 @@
 import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import _ from 'lodash';
-import { SimpleTransfer, TxReceipt } from '../../services/hedera';
+import { SimpleTransfer, TxReceipt } from '../../types/hedera';
 import { HederaServiceImpl } from '../../services/impl/hedera';
 import { createHederaClient } from '../../snap/account';
 import { generateCommonPanel, snapDialog } from '../../snap/dialog';

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/approveAllowance.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/approveAllowance.ts
@@ -28,7 +28,7 @@ import {
 import { ApproveAllowanceAssetDetail } from '../../../../types/params';
 import { uint8ArrayToHex } from '../../../../utils/crypto';
 import { timestampToString } from '../../../../utils/helper';
-import { TxReceipt } from '../../../hedera';
+import { TxReceipt } from '../../../../types/hedera';
 
 /**
  * Approve an allowance.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/createAccount.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/createAccount.ts
@@ -37,7 +37,7 @@ import {
   SimpleTransfer,
   TxReceipt,
   TxReceiptExchangeRate,
-} from '../../../hedera';
+} from '../../../../types/hedera';
 
 /**
  * Create a new account for someone else by transferring HBAR or any other token.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/deleteAccount.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/deleteAccount.ts
@@ -22,7 +22,7 @@ import { AccountDeleteTransaction, type Client } from '@hashgraph/sdk';
 
 import { uint8ArrayToHex } from '../../../../utils/crypto';
 import { timestampToString } from '../../../../utils/helper';
-import { TxReceipt } from '../../../hedera';
+import { TxReceipt } from '../../../../types/hedera';
 
 /**
  * Delete an account.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/deleteAllowance.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/deleteAllowance.ts
@@ -27,7 +27,7 @@ import {
 
 import { uint8ArrayToHex } from '../../../../utils/crypto';
 import { timestampToString } from '../../../../utils/helper';
-import { TxReceipt } from '../../../hedera';
+import { TxReceipt } from '../../../../types/hedera';
 
 /**
  * Approve an allowance.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/hts/associateTokens.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/hts/associateTokens.ts
@@ -26,7 +26,7 @@ import {
 
 import { uint8ArrayToHex } from '../../../../../utils/crypto';
 import { timestampToString } from '../../../../../utils/helper';
-import { TxReceipt } from '../../../../hedera';
+import { TxReceipt } from '../../../../../types/hedera';
 
 /**
  * Associate tokens to an account.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/index.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/index.ts
@@ -27,7 +27,11 @@ import {
 
 import { AccountInfo } from '../../../../types/account';
 import { ApproveAllowanceAssetDetail } from '../../../../types/params';
-import { SimpleHederaClient, SimpleTransfer, TxReceipt } from '../../../hedera';
+import {
+  SimpleHederaClient,
+  SimpleTransfer,
+  TxReceipt,
+} from '../../../../types/hedera';
 import { approveAllowance } from './approveAllowance';
 import { deleteAccount } from './deleteAccount';
 import { deleteAllowance } from './deleteAllowance';

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/stakeHbar.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/stakeHbar.ts
@@ -23,7 +23,7 @@ import { AccountUpdateTransaction, type Client } from '@hashgraph/sdk';
 import _ from 'lodash';
 import { uint8ArrayToHex } from '../../../../utils/crypto';
 import { timestampToString } from '../../../../utils/helper';
-import { TxReceipt } from '../../../hedera';
+import { TxReceipt } from '../../../../types/hedera';
 
 /**
  * Stake Hbar to a Node or another Acocunt ID.

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/transferCrypto.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/client/transferCrypto.ts
@@ -29,7 +29,7 @@ import { ethers } from 'ethers';
 import _ from 'lodash';
 import { uint8ArrayToHex } from '../../../../utils/crypto';
 import { timestampToString } from '../../../../utils/helper';
-import { SimpleTransfer, TxReceipt } from '../../../hedera';
+import { SimpleTransfer, TxReceipt } from '../../../../types/hedera';
 
 /**
  * Transfer crypto(hbar or other tokens).

--- a/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/index.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/services/impl/hedera/index.ts
@@ -46,7 +46,7 @@ import {
   SimpleHederaClient,
   Token,
   TokenBalance,
-} from '../../hedera';
+} from '../../../types/hedera';
 import { SimpleHederaClientImpl } from './client';
 
 export class HederaServiceImpl implements HederaService {

--- a/packages/hedera-wallet-snap/packages/snap/src/snap/account.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/snap/account.ts
@@ -23,7 +23,7 @@ import { providerErrors } from '@metamask/rpc-errors';
 import { divider, heading, text } from '@metamask/snaps-ui';
 import { ethers } from 'ethers';
 import _ from 'lodash';
-import { SimpleHederaClient } from '../services/hedera';
+import { SimpleHederaClient } from '../types/hedera';
 import { HederaServiceImpl, getHederaClient } from '../services/impl/hedera';
 import {
   Account,

--- a/packages/hedera-wallet-snap/packages/snap/src/types/account.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/types/account.ts
@@ -19,7 +19,7 @@
  */
 
 import { StakingInfoJson } from '@hashgraph/sdk/lib/account/AccountInfo';
-import { AccountBalance } from '../services/hedera';
+import { AccountBalance } from './hedera';
 
 export type ExternalAccount = {
   externalAccount: {

--- a/packages/hedera-wallet-snap/packages/snap/src/types/hedera.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/types/hedera.ts
@@ -31,8 +31,8 @@ import { Long } from '@hashgraph/sdk/lib/long';
 import { BigNumber } from 'bignumber.js';
 
 import { Wallet } from '../domain/wallet/abstract';
-import { AccountInfo } from '../types/account';
-import { ApproveAllowanceAssetDetail } from '../types/params';
+import { AccountInfo } from './account';
+import { ApproveAllowanceAssetDetail } from './params';
 
 export type SimpleTransfer = {
   assetType: 'HBAR' | 'TOKEN' | 'NFT';

--- a/packages/hedera-wallet-snap/packages/snap/src/types/params.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/types/params.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import { SimpleTransfer } from '../services/hedera';
+import { SimpleTransfer } from './hedera';
 
 export type MirrorNodeParams = { mirrorNodeUrl?: string };
 

--- a/packages/hedera-wallet-snap/packages/snap/src/utils/tuumService.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/utils/tuumService.ts
@@ -20,7 +20,7 @@
 
 import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
-import { SimpleHederaClient, SimpleTransfer } from '../services/hedera';
+import { SimpleHederaClient, SimpleTransfer } from '../types/hedera';
 
 export type QueryCost = {
   serviceFeeToPay: number;


### PR DESCRIPTION
**Description**:
Moving hedera types into the types/ folder for consistency.

**Related issue(s)**:
None.

**Notes for reviewer**:
One types file was not in the types/ folder, hedera.js which provides types used in the rest of the project. Also changed imports. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
