### PR TITLE
Throw error object instead error string for the snap apis

### DIFF
--- a/packages/hedera-wallet-snap/packages/snap/src/facades/TransferCryptoFacade.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/facades/TransferCryptoFacade.ts
@@ -249,13 +249,11 @@ export class TransferCryptoFacade {
       );
 
       txReceipt = await command.execute(hederaClient.getClient());
+
+      return txReceipt;
     } catch (error: any) {
       console.error(`Error while trying to transfer crypto: ${String(error)}`);
-      throw providerErrors.unsupportedMethod(
-        `Error while trying to transfer crypto: ${String(error)}`,
-      );
+      throw new Error(error);
     }
-
-    return txReceipt;
   }
 }

--- a/packages/hedera-wallet-snap/packages/snap/src/facades/hts/AssociateTokensFacade.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/facades/hts/AssociateTokensFacade.ts
@@ -133,14 +133,14 @@ export class AssociateTokensFacade {
       }
       const command = new AssociateTokensCommand(tokenIds);
       txReceipt = await command.execute(hederaClient.getClient());
+
+      return txReceipt;
     } catch (error: any) {
       const errMessage = `Error while trying to associate tokens to the account: ${String(
         error,
       )}`;
       console.error(errMessage);
-      throw providerErrors.unsupportedMethod(errMessage);
+      throw new Error(error);
     }
-
-    return txReceipt;
   }
 }


### PR DESCRIPTION
**Description**:
This change throws the error object instead error string for the snap apis.

**Related issue(s)**:
https://github.com/hashgraph/hedera-metamask-snaps/issues/195

Fixes #

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)