### PR TITLE
Fix: non-JSON-serializable value error in the snap

### DIFF
--- a/packages/hedera-wallet-snap/packages/snap/src/utils/HederaUtils.ts
+++ b/packages/hedera-wallet-snap/packages/snap/src/utils/HederaUtils.ts
@@ -2576,8 +2576,8 @@ export class HederaUtils {
       result.memo = mirrorNodeData.memo;
       result.evmAddress = mirrorNodeData.evm_address;
       result.key = {
-        type: mirrorNodeData.key._type,
-        key: mirrorNodeData.key.key,
+        type: mirrorNodeData?.key?._type,
+        key: mirrorNodeData?.key?.key,
       };
       result.autoRenewPeriod = String(mirrorNodeData.auto_renew_period);
       result.ethereumNonce = String(mirrorNodeData.ethereum_nonce);


### PR DESCRIPTION
This pull request changes the following:

- Makes the account result key's key and type value undefinable values given that the data can come back as null
