### PR TITLE
chore: replace pnpm/action-setup with a step-security maintained one

### DIFF
--- a/.github/workflows/flow-publish-release.yaml
+++ b/.github/workflows/flow-publish-release.yaml
@@ -151,7 +151,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || '' }}
 
       - name: Install PNPM
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: step-security/action-setup@303e8a1dabc4295b9b4ca0f4198fd42f7861406e # v4.0.0
         with:
           version: 8.10.0
 


### PR DESCRIPTION
## Description

pnpm/action-setup has to be replaced with a variant maintained by step-security in all workflows utilizing the action.

### Related Issues

- Closes #821 
