### PR TITLE
ci: Downgrade codecov-action to a stable version

### DIFF
--- a/.github/workflows/zxc-analyze-snap.yaml
+++ b/.github/workflows/zxc-analyze-snap.yaml
@@ -80,7 +80,7 @@ jobs:
           files: "packages/${{ inputs.snap-package-dir }}/**/junit-snap.xml"
 
       - name: Publish Coverage to CodeCov
-        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a # v5.0.2
         with:
           token: ${{ secrets.codecov-token }}
           slug: hashgraph/hedera-metamask-snaps


### PR DESCRIPTION
## Description

This pull request changes the following:

Downgrade codecov-action to a stable version

### Related Issues

- Closes #825 
