### PR TITLE
ci: replace action with step-security maintained version

### DIFF
--- a/.github/workflows/zxc-analyze-snap.yaml
+++ b/.github/workflows/zxc-analyze-snap.yaml
@@ -75,7 +75,7 @@ jobs:
         run: ls -la ${{ env.SNAP_DIRECTORY }}/coverage ${{ env.SNAP_DIRECTORY }}/junit*.xml
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         with:
           check_name: "${{ inputs.snap-report-name }} Unit Test Results"
           files: "packages/${{ inputs.snap-package-dir }}/**/junit-snap.xml"


### PR DESCRIPTION
## Description

This pull request changes the following:

- replaced EnricoMi/publish-unit-test-result-action with step-security version

### Related Issues

- Closes #1000
