### PR TITLE
chore: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,34 @@ updates:
       include: "scope"
     versioning-strategy: increase
     open-pull-requests-limit: 15
+
+  - package-ecosystem: npm
+    directory: "/packages/hedera-identify-snap"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    versioning-strategy: increase
+    open-pull-requests-limit: 15
+
+  - package-ecosystem: npm
+    directory: "/packages/hedera-identify-snap/packages/site"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    versioning-strategy: increase
+    open-pull-requests-limit: 15
+
+  - package-ecosystem: npm
+    directory: "/packages/hedera-identify-snap/packages/snap"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    versioning-strategy: increase
+    open-pull-requests-limit: 15
+  


### PR DESCRIPTION
**Description**:

Update dependabot.yaml to include the hedera-identify-snap packages in the npm ecosystem configuration for dependabot

**Related Issues**:

- Closes #1007 
